### PR TITLE
Use platform-independent `G_GINT64_FORMAT` to represent a `gint64`

### DIFF
--- a/src/csk/backlight.c
+++ b/src/csk/backlight.c
@@ -61,7 +61,7 @@ static gint64 get_backlight(void)
 
 static gboolean set_backlight(gint64 val)
 {
-	gchar *sval = g_strdup_printf("%lli", val);
+	gchar *sval = g_strdup_printf("%"G_GINT64_FORMAT, val);
 	gint exitCode;
 	gboolean r = backlight_command(BH_SET, sval, NULL, &exitCode);
 	g_free(sval);


### PR DESCRIPTION
As it turns out, https://github.com/VeltOS/graphene-desktop/pull/14 is a platform-dependent case and thus should be using `G_GINT64_FORMAT`

source: https://developer.gnome.org/glib/stable/glib-Basic-Types.html#G-GINT64-FORMAT:CAPS