### PR TITLE
A quick fix for building against Gnome 3.22+

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_command(
 )
 
 pkg_check_modules(GIOUNIX2 REQUIRED gio-unix-2.0>=2.10)
-pkg_check_modules(LIBMUTTER REQUIRED libmutter-1>=3.22)
+pkg_check_modules(LIBMUTTER REQUIRED libmutter-2>=3.22)
 pkg_check_modules(LIBPULSEGLIB REQUIRED libpulse-mainloop-glib>=8.0)
 pkg_check_modules(POLKITAGENT REQUIRED polkit-agent-1)
 pkg_check_modules(LIBGNOMEMENU REQUIRED libgnome-menu-3.0>=3.13)


### PR DESCRIPTION
As libmutter changed in Gnome 3.26 (september 2017), a quick fix for this bug : https://github.com/VeltOS/graphene-desktop/issues/13